### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing Guide
+
+## Branch Naming
+- `feature/your-feature-name`
+- `fix/bug-description`
+- `data/task-name`
+- `docs/what-you-documented`
+
+## Workflow
+1. Pick an issue and comment "I'd like to work on this"
+2. Branch from `develop`
+3. Make your changes with clear commits
+4. Open a Pull Request → `develop`
+5. Wait for 1 reviewer approval
+6. Maintainer merges
+
+## Commit Message Format
+- `feat: add preprocessing for bodily location column`
+- `fix: handle missing values in Total Paid column`
+- `docs: update README with dataset description`
+- `test: add unit tests for RTW category encoder`
+
+## Never commit
+- Raw or real data files
+- Jupyter notebook outputs
+- API keys or credentials


### PR DESCRIPTION
Added a contributing guide with branch naming, workflow, and commit message format.